### PR TITLE
fixes #6: image frame file name in the event document

### DIFF
--- a/plans/interlace_tomo.py
+++ b/plans/interlace_tomo.py
@@ -207,8 +207,9 @@ class FrameNotifier(CallbackBase):
 
     def event(self, doc):
         if self.hdf is not None:
-            logger.info(self.hdf.full_file_name.get())
-            print(self.hdf.full_file_name.get())
+            frame_name = self.hdf.full_file_name.get()
+            logger.info(frame_name)
+            #print(self.hdf.full_file_name.get())
 
 
 class EPICSNotifierCallback(CallbackBase):

--- a/plans/standlone.py
+++ b/plans/standlone.py
@@ -234,7 +234,8 @@ if __name__ == '__main__':
     epics_notifier = interlace_tomo.EPICSNotifierCallback(epics_string_notices)
     
     detectors = [simdet]
-    live_table = LiveTable([alpha, beta])
+    live_table_signals = [alpha, beta]
+    live_table = LiveTable(live_table_signals)
 
     tomo_callbacks.append(prescan_checks)
     tomo_callbacks.append(live_table)


### PR DESCRIPTION
With the `myHDF5Plugin` class the info is in the event document, but in
two parts (file_name & file_number; full_file_name, a waveform string,
is not rendered ... yet)

The code (`interlace.tomo.FrameNotifier.event()`) shows how to access
the full name of the frame file from within the event handler.

BUT, this method completely ignores the filestore and its handling.
That will be an upgrade for the next phase.